### PR TITLE
Update app.js to include pm2 syslog tag

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ var pmx     = require('pmx');
 var pm2     = require('pm2');
 
 var SysLogger = require('ain2');
-var logger    = new SysLogger({facility: 'syslog'});
+var logger = new SysLogger({tag: 'pm2', facility: 'syslog'});
 
 var conf    = pmx.initModule();
 


### PR DESCRIPTION
Tag the syslog output as pm2 so that in the logs it does not show just "hostname - error" but "hostname - pm2 - error"

BEFORE:
May 25 16:29:08 noc.pv.domain.com /root/.pm2/node_modules/ain2/index.js[81027]:Process test2 restarted 21

AFTER:
May 25 16:44:35 noc.pv.domain.com pm2[86262]:Process test2 restarted 114
