### PR TITLE
Add ability to configure module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 Redirect all logs of PM2 + Apps managed into `/var/log/syslog`
 
-## Configure OS
+OR
+
+Into standard syslog socket
+
+```
+# You can use any config parameter that ain2 supports
+pm2 set pm2-syslog:path /dev/log
+```
+
+## Configure OS (if not using socket)
 
 Edit `/etc/rsyslog.conf` and uncomment:
 

--- a/app.js
+++ b/app.js
@@ -1,28 +1,27 @@
-
+var pmx       = require('pmx');
 var pm2       = require('pm2');
 var SysLogger = require('ain2');
-var logger    = new SysLogger({
-  tag: 'pm2',
-  facility: 'syslog',
-  path: '/dev/log'
-});
 
-pm2.launchBus(function(err, bus) {
-  bus.on('*', function(event, data){
-    if (event == 'process:event') {
-      logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
-                  data.process.name,
-                  data.process.pm_id,
-                  data.process.restart_time,
-                  data.event);
-    }
-  });
+var conf      = pmx.initModule({}, (err, conf) => {
+  var logger    = new SysLogger(conf);
 
-  bus.on('log:err', function(data) {
-    logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
-  });
+  pm2.launchBus(function(err, bus) {
+    bus.on('*', function(event, data){
+      if (event == 'process:event') {
+        logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
+                    data.process.name,
+                    data.process.pm_id,
+                    data.process.restart_time,
+                    data.event);
+      }
+    });
 
-  bus.on('log:out', function(data) {
-    logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+    bus.on('log:err', function(data) {
+      logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+    });
+
+    bus.on('log:out', function(data) {
+      logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+    });
   });
 });

--- a/app.js
+++ b/app.js
@@ -1,7 +1,11 @@
 
 var pm2       = require('pm2');
 var SysLogger = require('ain2');
-var logger    = new SysLogger({tag: 'pm2',  facility: 'syslog'});
+var logger    = new SysLogger({
+  tag: 'pm2',
+  facility: 'syslog',
+  path: '/dev/log'
+});
 
 pm2.launchBus(function(err, bus) {
   bus.on('*', function(event, data){

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "script": "app.js"
     }
   ],
+  "config": {
+    "tag": "pm2",
+    "facility": "syslog"
+  },
   "author": "Alexandre Strzelewicz",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "ain2": "^2.0.0",
-    "pm2": "latest"
+    "pm2": "latest",
+    "unix-dgram": "^2.0.1"
   },
   "apps": [
     {


### PR DESCRIPTION
By default, it behaves as before.

But you may set any of the parameters that ain2 expects. Most notably `path` - which allows you to direct logs to the system log socket, `/dev/log`.

This is the desired configuration in my network (opening extra TCP ports when not necessary is frowned upon).